### PR TITLE
Add support for boot and shutdown time in ms and immediate boot and shutdown time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ gradle.properties
 
 # Generated Java stubs (with Apache-CXF)
 src/main/java/com/tlswe/awsmock/ec2/cxf_generated/*.java
+
+# IntelliJ files
+.idea/
+*.iml
+gradle
+gradlew*

--- a/src/main/java/com/tlswe/awsmock/common/util/Constants.java
+++ b/src/main/java/com/tlswe/awsmock/common/util/Constants.java
@@ -49,22 +49,42 @@ public interface Constants {
     String PROP_NAME_XMLNS_CURRENT = "xmlns.current";
 
     /**
-     * Property name for max shutdown time of a mock EC2 instance.
+     * Property name for max shutdown time of a mock EC2 instance in milliseconds.
+     */
+    String PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME = "instance.max.shutdown.time";
+
+    /**
+     * Property name for max shutdown time of a mock EC2 instance in seconds.
      */
     String PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME_SECONDS = "instance.max.shutdown.time.seconds";
 
     /**
-     * Property name for min shutdown time of a mock EC2 instance.
+     * Property name for min shutdown time of a mock EC2 instance in milliseconds.
+     */
+    String PROP_NAME_INSTANCE_MIN_SHUTDOWN_TIME = "instance.min.shutdown.time";
+
+    /**
+     * Property name for min shutdown time of a mock EC2 instance in seconds.
      */
     String PROP_NAME_INSTANCE_MIN_SHUTDOWN_TIME_SECONDS = "instance.min.shutdown.time.seconds";
 
     /**
-     * Property name for max boot time of a mock EC2 instance.
+     * Property name for max boot time of a mock EC2 instance in milliseconds.
+     */
+    String PROP_NAME_INSTANCE_MAX_BOOT_TIME = "instance.max.boot.time";
+
+    /**
+     * Property name for max boot time of a mock EC2 instance in seconds.
      */
     String PROP_NAME_INSTANCE_MAX_BOOT_TIME_SECONDS = "instance.max.boot.time.seconds";
 
     /**
-     * Property name for min boot time of a mock EC2 instance.
+     * Property name for min boot time of a mock EC2 instance in milliseconds.
+     */
+    String PROP_NAME_INSTANCE_MIN_BOOT_TIME = "instance.min.boot.time";
+
+    /**
+     * Property name for min boot time of a mock EC2 instance in seconds.
      */
     String PROP_NAME_INSTANCE_MIN_BOOT_TIME_SECONDS = "instance.min.boot.time.seconds";
 }

--- a/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
@@ -1,16 +1,11 @@
 package com.tlswe.awsmock.ec2.model;
 
-import java.io.Serializable;
-import java.util.Random;
-import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.TreeSet;
-import java.util.UUID;
-
 import com.tlswe.awsmock.common.exception.AwsMockException;
 import com.tlswe.awsmock.common.util.Constants;
 import com.tlswe.awsmock.common.util.PropertiesUtils;
+
+import java.io.Serializable;
+import java.util.*;
 
 /**
  * Generic class for mock ec2 instance, with basic simulation of behaviors and states of genuine ec2 instances' life
@@ -294,7 +289,7 @@ public abstract class AbstractMockEc2Instance implements Serializable {
     }
 
     /**
-     * Interval for the internal timer thread that triggered for state chacking and changing - we set it for 10 seconds.
+     * Interval for the internal timer thread that triggered for state checking and changing - we set it for 10 seconds.
      */
     public static final int TIMER_INTERVAL_MILLIS = 10 * 1000;
 

--- a/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
@@ -492,13 +492,15 @@ public abstract class AbstractMockEc2Instance implements Serializable {
                         if (booting) {
 
                             // delay a random 'boot time'
-                            try {
-                                Thread.sleep(MIN_BOOT_TIME_MILLS
-                                        + random.nextInt((int) (MAX_BOOT_TIME_MILLS - MIN_BOOT_TIME_MILLS)));
-                            } catch (InterruptedException e) {
-                                throw new AwsMockException(
-                                        "InterruptedException caught when delaying a mock random 'boot time'",
-                                        e);
+                            if (MAX_BOOT_TIME_MILLS != 0) {
+                                try {
+                                    Thread.sleep(MIN_BOOT_TIME_MILLS
+                                            + random.nextInt((int) (MAX_BOOT_TIME_MILLS - MIN_BOOT_TIME_MILLS)));
+                                } catch (InterruptedException e) {
+                                    throw new AwsMockException(
+                                            "InterruptedException caught when delaying a mock random 'boot time'",
+                                            e);
+                                }
                             }
 
                             // booted, assign a mock pub dns name
@@ -511,14 +513,16 @@ public abstract class AbstractMockEc2Instance implements Serializable {
                         } else if (stopping) {
 
                             // delay a random 'shutdown time'
-                            try {
-                                Thread.sleep(MIN_SHUTDOWN_TIME_MILLS
-                                        + random.nextInt((int) (MAX_SHUTDOWN_TIME_MILLS
-                                                - MIN_SHUTDOWN_TIME_MILLS)));
-                            } catch (InterruptedException e) {
-                                throw new AwsMockException(
-                                        "InterruptedException caught when delaying a mock random 'shutdown time'",
-                                        e);
+                            if (MAX_SHUTDOWN_TIME_MILLS != 0) {
+                                try {
+                                    Thread.sleep(MIN_SHUTDOWN_TIME_MILLS
+                                            + random.nextInt((int) (MAX_SHUTDOWN_TIME_MILLS
+                                                    - MIN_SHUTDOWN_TIME_MILLS)));
+                                } catch (InterruptedException e) {
+                                    throw new AwsMockException(
+                                            "InterruptedException caught when delaying a mock random 'shutdown time'",
+                                            e);
+                                }
                             }
 
                             // unset pub dns name

--- a/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
@@ -301,30 +301,37 @@ public abstract class AbstractMockEc2Instance implements Serializable {
     /**
      * Minimal boot time.
      */
-    public static final long MIN_BOOT_TIME_MILLS = Integer
-            .parseInt(PropertiesUtils
-                    .getProperty(Constants.PROP_NAME_INSTANCE_MIN_BOOT_TIME_SECONDS)) * 1000L;
+    public static final long MIN_BOOT_TIME_MILLS;
 
     /**
      * Maximum boot time.
      */
-    protected static final long MAX_BOOT_TIME_MILLS = Integer
-            .parseInt(PropertiesUtils
-                    .getProperty(Constants.PROP_NAME_INSTANCE_MAX_BOOT_TIME_SECONDS)) * 1000L;
+    protected static final long MAX_BOOT_TIME_MILLS;
 
     /**
      * Minimal shutdown time.
      */
-    protected static final long MIN_SHUTDOWN_TIME_MILLS = Integer
-            .parseInt(PropertiesUtils
-                    .getProperty(Constants.PROP_NAME_INSTANCE_MIN_SHUTDOWN_TIME_SECONDS)) * 1000L;
+    protected static final long MIN_SHUTDOWN_TIME_MILLS;
 
     /**
      * maximum shutdown time.
      */
-    protected static final long MAX_SHUTDOWN_TIME_MILLS = Integer
-            .parseInt(PropertiesUtils
-                    .getProperty(Constants.PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME_SECONDS)) * 1000L;
+    protected static final long MAX_SHUTDOWN_TIME_MILLS;
+
+    private static long getMsFromProperty(String propertyName, String propertyNameInSeconds) {
+        String property = PropertiesUtils.getProperty(propertyName);
+        if (property != null) {
+            return Long.parseLong(property);
+        }
+        return Integer.parseInt(PropertiesUtils.getProperty(propertyNameInSeconds)) * 1000L;
+    }
+
+    static {
+        MIN_BOOT_TIME_MILLS = getMsFromProperty(Constants.PROP_NAME_INSTANCE_MIN_BOOT_TIME, Constants.PROP_NAME_INSTANCE_MIN_BOOT_TIME_SECONDS);
+        MAX_BOOT_TIME_MILLS = getMsFromProperty(Constants.PROP_NAME_INSTANCE_MAX_BOOT_TIME, Constants.PROP_NAME_INSTANCE_MAX_BOOT_TIME_SECONDS);
+        MIN_SHUTDOWN_TIME_MILLS = getMsFromProperty(Constants.PROP_NAME_INSTANCE_MIN_SHUTDOWN_TIME, Constants.PROP_NAME_INSTANCE_MIN_SHUTDOWN_TIME_SECONDS);
+        MAX_SHUTDOWN_TIME_MILLS = getMsFromProperty(Constants.PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME, Constants.PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME_SECONDS);
+    }
 
     /**
      * instance ID, randomly assigned on creating.

--- a/src/main/resources/aws-mock-default.properties
+++ b/src/main/resources/aws-mock-default.properties
@@ -24,6 +24,13 @@ instance.max.boot.time.seconds=30
 instance.min.shutdown.time.seconds=6
 instance.max.shutdown.time.seconds=20
 
+# min/max boot/shutdown time (in milliseconds) for a mock ec2 instance
+# Setting time in ms has precedence to seconds
+# instance.min.boot.time=15000
+# instance.max.boot.time=30000
+# instance.min.shutdown.time=6000
+# instance.max.shutdown.time=20000
+
 # simple file based persistence (only save on context stopping and load on context starting)
 persistence.enabled=false
 # point to the target file to which you would like to make runtime objects persistent


### PR DESCRIPTION
This patch adds support for new properties which defines time for booting or shutting down instances in milliseconds:

* `instance.max.shutdown.time`
* `instance.min.shutdown.time`
* `instance.max.boot.time`
* `instance.min.boot.time`

If those properties are set and the ones with `.seconds` suffix as well, those in milliseconds have precedence.

It also adds support for immediate boot and shutdown time

For some unit tests, we don't need to wait for boot time or shutdown time as we only want to mock the EC2 API.
This commit adds support to 0 as a MAX TIME for boot or shutdown.
