### PR TITLE
Add network related APIs and state filter for describing instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM java:8
+
+RUN apt-get update
+RUN apt-get install -y gradle
+
+WORKDIR /project
+
+ADD . /project/
+CMD ["gradle", "jettyRun"]
+
+EXPOSE 8000

--- a/src/main/java/com/tlswe/awsmock/common/util/Constants.java
+++ b/src/main/java/com/tlswe/awsmock/common/util/Constants.java
@@ -87,4 +87,70 @@ public interface Constants {
      * Property name for min boot time of a mock EC2 instance in seconds.
      */
     String PROP_NAME_INSTANCE_MIN_BOOT_TIME_SECONDS = "instance.min.boot.time.seconds";
+
+    /**
+     * Property name for vpc id.
+     */
+    String PROP_NAME_VPC_ID = "network.vpcId";
+
+    /**
+     * Property name for vpc state.
+     */
+    String PROP_NAME_VPC_STATE = "network.vpcState";
+
+    /**
+     * Property name for subnet id.
+     */
+    String PROP_NAME_SUBNET_ID = "network.subnetId";
+
+    /**
+     * Property name for private ip address.
+     */
+    String PROP_NAME_PRIVATE_IP_ADDRESS = "network.privateIpAddress";
+
+    /**
+     * Property name for route table id.
+     */
+    String PROP_NAME_ROUTE_TABLE_ID = "network.routeTableId";
+
+    /**
+     * Property name for internet gateway id.
+     */
+    String PROP_NAME_GATEWAY_ID = "network.internetGatewayId";
+
+    /**
+     * Property name for security group id.
+     */
+    String PROP_NAME_SECURITY_GROUP_ID = "network.securityGroupId";
+
+    /**
+     * Property name for security owner id.
+     */
+    String PROP_NAME_SECURITY_OWNER_ID = "network.securityOwnerId";
+
+    /**
+     * Property name for security owner id.
+     */
+    String PROP_NAME_SECURITY_GROUP_NAME = "network.securityGroupName";
+
+    /**
+     * Property name for ip protocol.
+     */
+    String PROP_NAME_IP_PROTOCOL = "network.ipProtocol";
+
+    /**
+     * Property name for cidr block.
+     */
+    String PROP_NAME_CIDR_BLOCK = "network.cidrBlock";
+
+    /**
+     * Property name for source ip port.
+     */
+    String PROP_NAME_SOURCE_PORT = "network.sourcePort";
+
+    /**
+     * Property name for destination ip port.
+     */
+    String PROP_NAME_DEST_PORT = "network.destPort";
+
 }

--- a/src/main/java/com/tlswe/awsmock/common/util/PropertiesUtils.java
+++ b/src/main/java/com/tlswe/awsmock/common/util/PropertiesUtils.java
@@ -117,4 +117,21 @@ public final class PropertiesUtils {
         return ret;
     }
 
+
+    /**
+     * Get int type of property value by name.
+     *
+     * @param propertyName
+     *            name of the property to get
+     * @return int type of value
+     */
+    public static int getIntFromProperty(final String propertyName) {
+        try {
+            return Integer.parseInt(properties.getProperty(propertyName));
+        } catch (NumberFormatException e) {
+            log.error("NumberFormatException caught during reading property from properties file: " + e.getMessage());
+            return 0;
+        }
+    }
+
 }

--- a/src/main/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandler.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandler.java
@@ -36,6 +36,22 @@ import com.tlswe.awsmock.ec2.cxf_generated.RunningInstancesSetType;
 import com.tlswe.awsmock.ec2.cxf_generated.StartInstancesResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.StopInstancesResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.TerminateInstancesResponseType;
+import com.tlswe.awsmock.ec2.cxf_generated.DescribeRouteTablesResponseType;
+import com.tlswe.awsmock.ec2.cxf_generated.RouteTableSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.RouteTableType;
+import com.tlswe.awsmock.ec2.cxf_generated.RouteTableAssociationSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.RouteSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.DescribeInternetGatewaysResponseType;
+import com.tlswe.awsmock.ec2.cxf_generated.InternetGatewayType;
+import com.tlswe.awsmock.ec2.cxf_generated.InternetGatewaySetType;
+import com.tlswe.awsmock.ec2.cxf_generated.DescribeSecurityGroupsResponseType;
+import com.tlswe.awsmock.ec2.cxf_generated.SecurityGroupSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.SecurityGroupItemType;
+import com.tlswe.awsmock.ec2.cxf_generated.IpPermissionType;
+import com.tlswe.awsmock.ec2.cxf_generated.IpPermissionSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.DescribeVpcsResponseType;
+import com.tlswe.awsmock.ec2.cxf_generated.VpcSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.VpcType;
 import com.tlswe.awsmock.ec2.exception.BadEc2RequestException;
 import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
 import com.tlswe.awsmock.ec2.servlet.MockEc2EndpointServlet;
@@ -99,6 +115,76 @@ public final class MockEC2QueryHandler {
      * Instance of {@link MockEc2Controller} uesed in this class that controls mock EC2 instances.
      */
     private final MockEc2Controller mockEc2Controller = MockEc2Controller.getInstance();
+
+    /**
+     * Predefined mock vpc id.
+     */
+    private static final String MOCK_VPC_ID = PropertiesUtils.getProperty(Constants.PROP_NAME_VPC_ID);
+
+    /**
+     * Predefined mock vpc state.
+     */
+    private static final String MOCK_VPC_STATE = PropertiesUtils.getProperty(Constants.PROP_NAME_VPC_STATE);
+
+    /**
+     * Predefined mock private ip address.
+     */
+    private static final String MOCK_PRIVATE_IP_ADDRESS = PropertiesUtils.
+            getProperty(Constants.PROP_NAME_PRIVATE_IP_ADDRESS);
+
+    /**
+     * Predefined mock subnet id.
+     */
+    private static final String MOCK_SUBNET_ID = PropertiesUtils.getProperty(Constants.PROP_NAME_SUBNET_ID);
+
+    /**
+     * Predefined mock route table id.
+     */
+    private static final String MOCK_ROUTE_TABLE_ID = PropertiesUtils.getProperty(Constants.PROP_NAME_ROUTE_TABLE_ID);
+
+    /**
+     * Predefined mock internet gateway id.
+     */
+    private static final String MOCK_GATEWAY_ID = PropertiesUtils.getProperty(Constants.PROP_NAME_GATEWAY_ID);
+
+    /**
+     * Predefined mock security group id.
+     */
+    private static final String MOCK_SECURITY_GROUP_ID = PropertiesUtils.
+            getProperty(Constants.PROP_NAME_SECURITY_GROUP_ID);
+
+    /**
+     * Predefined mock security owner id.
+     */
+    private static final String MOCK_SECURITY_OWNER_ID = PropertiesUtils.
+            getProperty(Constants.PROP_NAME_SECURITY_OWNER_ID);
+
+    /**
+     * Predefined mock security group name.
+     */
+    private static final String MOCK_SECURITY_GROUP_NAME = PropertiesUtils.
+            getProperty(Constants.PROP_NAME_SECURITY_GROUP_NAME);
+
+    /**
+     * Predefined mock ip protocol.
+     */
+    private static final String MOCK_IP_PROTOCOL = PropertiesUtils.getProperty(Constants.PROP_NAME_IP_PROTOCOL);
+
+    /**
+     * Predefined mock cidr block.
+     */
+    private static final String MOCK_CIDR_BLOCK = PropertiesUtils.getProperty(Constants.PROP_NAME_CIDR_BLOCK);
+
+    /**
+     * Predefined mock source ip port.
+     */
+    private static final int MOCK_SOURCE_PORT = PropertiesUtils.getIntFromProperty(Constants.PROP_NAME_SOURCE_PORT);
+
+    /**
+     * Predefined mock destination ip port.
+     */
+    private static final int MOCK_DEST_PORT = PropertiesUtils.getIntFromProperty(Constants.PROP_NAME_DEST_PORT);
+
 
     static {
         DEFAULT_MOCK_PLACEMENT.setAvailabilityZone(PropertiesUtils.getProperty(Constants.PROP_NAME_EC2_PLACEMENT));
@@ -206,7 +292,9 @@ public final class MockEC2QueryHandler {
 
                             if ("DescribeInstances".equals(action)) {
 
-                                responseXml = JAXBUtil.marshall(describeInstances(instanceIDs),
+                                Set<String> instanceStates = parseInstanceStates(queryParams);
+
+                                responseXml = JAXBUtil.marshall(describeInstances(instanceIDs, instanceStates),
                                         "DescribeInstancesResponse", version);
 
                             } else if ("StartInstances".equals(action)) {
@@ -223,6 +311,26 @@ public final class MockEC2QueryHandler {
 
                                 responseXml = JAXBUtil.marshall(terminateInstances(instanceIDs),
                                         "TerminateInstancesResponse", version);
+
+                            } else if ("DescribeVpcs".equals(action)) {
+
+                                responseXml = JAXBUtil.marshall(describeVpcs(),
+                                        "DescribeVpcsResponse", version);
+
+                            } else if ("DescribeSecurityGroups".equals(action)) {
+
+                                responseXml = JAXBUtil.marshall(describeSecurityGroups(),
+                                        "DescribeSecurityGroupsResponse", version);
+
+                            } else if ("DescribeInternetGateways".equals(action)) {
+
+                                responseXml = JAXBUtil.marshall(describeInternetGateways(),
+                                        "DescribeInternetGatewaysResponse", version);
+
+                            } else if ("DescribeRouteTables".equals(action)) {
+
+                                responseXml = JAXBUtil.marshall(describeRouteTables(),
+                                        "DescribeRouteTablesResponse", version);
 
                             } else {
 
@@ -260,6 +368,28 @@ public final class MockEC2QueryHandler {
 
 
     /**
+     * Parse instance states from query parameters.
+     *
+     * @param queryParams
+     *            map of query parameters in http request
+     * @return a set of instance states in the parameter map
+     */
+    private Set<String> parseInstanceStates(final Map<String, String[]> queryParams) {
+        Set<String> instanceStates = new TreeSet<String>();
+
+        for (String queryKey : queryParams.keySet()) {
+            // e.g. Filter.1.Value.1: running, Filter.1.Value.2: pending
+            if (queryKey.startsWith("Filter.1.Value")) {
+                for (String state : queryParams.get(queryKey)) {
+                    instanceStates.add(state);
+                }
+            }
+        }
+        return instanceStates;
+    }
+
+
+    /**
      * Parse instance IDs from query parameters.
      *
      * @param queryParams
@@ -282,14 +412,17 @@ public final class MockEC2QueryHandler {
 
 
     /**
-     * Handles "describeInstances" request, with only a simplified filter of instanceIDs, and returns response with all
-     * mock ec2 instances if no instance IDs specified.
+     * Handles "describeInstances" request, with filters of instanceIDs and instanceStates, and
+     * returns response with all mock ec2 instances if no instance IDs specified.
      *
      * @param instanceIDs
      *            a filter of specified instance IDs for the target instance to describe
+     * @param instanceStates
+     *            a filter of specified instance states for the target instance to describe
      * @return a DescribeInstancesResponse with information for all mock ec2 instances to describe
      */
-    private DescribeInstancesResponseType describeInstances(final Set<String> instanceIDs) {
+    private DescribeInstancesResponseType describeInstances(final Set<String> instanceIDs,
+            final Set<String> instanceStates) {
 
         DescribeInstancesResponseType ret = new DescribeInstancesResponseType();
         ret.setRequestId(UUID.randomUUID().toString());
@@ -302,6 +435,11 @@ public final class MockEC2QueryHandler {
         for (AbstractMockEc2Instance instance : instances) {
 
             if (null != instance) {
+                String instanceState = instance.getInstanceState().getName();
+                // get instances with specified states
+                if (!instanceStates.isEmpty() && !instanceStates.contains(instanceState)) {
+                    continue;
+                }
 
                 ReservationInfoType resInfo = new ReservationInfoType();
                 resInfo.setReservationId(UUID.randomUUID().toString());
@@ -329,6 +467,11 @@ public final class MockEC2QueryHandler {
                 instItem.setInstanceType(instance.getInstanceType().getName());
                 instItem.setDnsName(instance.getPubDns());
 
+                // set network information
+                instItem.setVpcId(MOCK_VPC_ID);
+                instItem.setPrivateIpAddress(MOCK_PRIVATE_IP_ADDRESS);
+                instItem.setSubnetId(MOCK_SUBNET_ID);
+
                 instsSet.getItem().add(instItem);
 
                 resInfo.setInstancesSet(instsSet);
@@ -352,7 +495,7 @@ public final class MockEC2QueryHandler {
      * @param imageId
      *            AMI of new mock ec2 instance(s)
      * @param instanceType
-     *            type(scale) of new mock ec2 instance(s), refer to {@link AbstractMockEc2Instance#InstanceType}
+     *            type(scale) of new mock ec2 instance(s), refer to {@link AbstractMockEc2Instance#instanceType}
      * @param minCount
      *            max count of instances to run
      * @param maxCount
@@ -394,6 +537,11 @@ public final class MockEC2QueryHandler {
             instItem.setInstanceState(state);
             instItem.setDnsName(i.getPubDns());
             instItem.setPlacement(DEFAULT_MOCK_PLACEMENT);
+
+            // set network information
+            instItem.setVpcId(MOCK_VPC_ID);
+            instItem.setPrivateIpAddress(MOCK_PRIVATE_IP_ADDRESS);
+            instItem.setSubnetId(MOCK_SUBNET_ID);
 
             instSet.getItem().add(instItem);
 
@@ -474,6 +622,121 @@ public final class MockEC2QueryHandler {
             info.getItem().add(item);
         }
         ret.setImagesSet(info);
+
+        return ret;
+    }
+
+
+    /**
+     * Handles "describeRouteTables" request and returns response with a route table.
+     *
+     * @return a DescribeRouteTablesResponseType with our predefined route table in aws-mock.properties
+     * (or if not overridden, as defined in aws-mock-default.properties)
+     */
+    private DescribeRouteTablesResponseType describeRouteTables() {
+        DescribeRouteTablesResponseType ret = new DescribeRouteTablesResponseType();
+        ret.setRequestId(UUID.randomUUID().toString());
+
+        RouteTableSetType routeTableSet = new RouteTableSetType();
+
+        RouteTableType routeTable = new RouteTableType();
+        routeTable.setVpcId(MOCK_VPC_ID);
+        routeTable.setRouteTableId(MOCK_ROUTE_TABLE_ID);
+
+        RouteTableAssociationSetType associationSet = new RouteTableAssociationSetType();
+        routeTable.setAssociationSet(associationSet);
+
+        RouteSetType routeSet = new RouteSetType();
+        routeTable.setRouteSet(routeSet);
+
+        routeTableSet.getItem().add(routeTable);
+        ret.setRouteTableSet(routeTableSet);
+
+        return ret;
+    }
+
+
+    /**
+     * Handles "describeInternetGateways" request and returns response with a internet gateway.
+     *
+     * @return a DescribeInternetGatewaysResponseType with our predefined internet gateway in aws-mock.properties
+     * (or if not overridden, as defined in aws-mock-default.properties)
+     */
+    private DescribeInternetGatewaysResponseType describeInternetGateways() {
+        DescribeInternetGatewaysResponseType ret = new DescribeInternetGatewaysResponseType();
+
+        InternetGatewayType internetGateway = new InternetGatewayType();
+        internetGateway.setInternetGatewayId(MOCK_GATEWAY_ID);
+
+        InternetGatewaySetType internetGatewaySet = new InternetGatewaySetType();
+        internetGatewaySet.getItem().add(internetGateway);
+
+        ret.setInternetGatewaySet(internetGatewaySet);
+
+        return ret;
+    }
+
+
+    /**
+     * Handles "describeSecurityGroups" request and returns response with a security group.
+     *
+     * @return a DescribeInternetGatewaysResponseType with our predefined internet gateway in aws-mock.properties
+     * (or if not overridden, as defined in aws-mock-default.properties)
+     */
+    private DescribeSecurityGroupsResponseType describeSecurityGroups() {
+        DescribeSecurityGroupsResponseType ret = new DescribeSecurityGroupsResponseType();
+        ret.setRequestId(UUID.randomUUID().toString());
+
+        SecurityGroupSetType securityGroupSet = new SecurityGroupSetType();
+
+        // initialize securityGroupItem
+        SecurityGroupItemType securityGroupItem = new SecurityGroupItemType();
+        securityGroupItem.setOwnerId(MOCK_SECURITY_OWNER_ID);
+        securityGroupItem.setGroupName(MOCK_SECURITY_GROUP_NAME);
+        securityGroupItem.setGroupId(MOCK_SECURITY_GROUP_ID);
+        securityGroupItem.setVpcId(MOCK_VPC_ID);
+
+        // initialize ipPermission
+        IpPermissionType ipPermission = new IpPermissionType();
+        ipPermission.setFromPort(MOCK_SOURCE_PORT);
+        ipPermission.setToPort(MOCK_DEST_PORT);
+        ipPermission.setIpProtocol(MOCK_IP_PROTOCOL);
+
+        // initialize ipPermissionSet
+        IpPermissionSetType ipPermissionSet = new IpPermissionSetType();
+        ipPermissionSet.getItem().add(ipPermission);
+
+        securityGroupItem.setIpPermissions(ipPermissionSet);
+
+        securityGroupSet.getItem().add(securityGroupItem);
+        ret.setSecurityGroupInfo(securityGroupSet);
+
+        return ret;
+    }
+
+
+    /**
+     * Handles "describeVpcs" request and returns response with a vpc.
+     *
+     * @return a DescribeVpcsResponseType with our predefined vpc in aws-mock.properties
+     * (or if not overridden, as defined in aws-mock-default.properties)
+     */
+    private DescribeVpcsResponseType describeVpcs() {
+        DescribeVpcsResponseType ret = new DescribeVpcsResponseType();
+        ret.setRequestId(UUID.randomUUID().toString());
+
+        VpcSetType vpcSet = new VpcSetType();
+
+        // initialize vpc
+        VpcType vpcType = new VpcType();
+        vpcType.setVpcId(MOCK_VPC_ID);
+        vpcType.setState(MOCK_VPC_STATE);
+        vpcType.setCidrBlock(MOCK_CIDR_BLOCK);
+        vpcType.setIsDefault(true);
+
+        vpcSet.getItem().add(vpcType);
+
+        ret.setVpcSet(vpcSet);
 
         return ret;
     }

--- a/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
@@ -76,6 +76,62 @@ public abstract class AbstractMockEc2Instance implements Serializable {
          */
         M1_XLARGE("m1.xlarge"),
         /**
+         * m3.medium.
+         */
+        M3_MEDIUM("m3.medium"),
+        /**
+         * m3.large.
+         */
+        M3_LARGE("m3.large"),
+        /**
+         * m3.xlarge.
+         */
+        M3_XLARGE("m3.xlarge"),
+        /**
+         * m3.2xlarge.
+         */
+        M3_2XLARGE("m3.2xlarge"),
+        /**
+         * m4.large.
+         */
+        M4_LARGE("m4.large"),
+        /**
+         * m4.xlarge.
+         */
+        M4_XLARGE("m4.xlarge"),
+        /**
+         * m4.2xlarge.
+         */
+        M4_2XLARGE("m4.2xlarge"),
+        /**
+         * m4.4xlarge.
+         */
+        M4_4XLARGE("m4.4xlarge"),
+        /**
+         * m4.10xlarge.
+         */
+        M4_10XLARGE("m4.10xlarge"),
+        /**
+         * t2.nano.
+         */
+        T2_NANO("t2.nano"),
+        /**
+         * t2.micro.
+         */
+        T2_MICRO("t2.micro"),
+        /**
+         * t2.small.
+         */
+        T2_SMALL("t2.small"),
+        /**
+         * t2.medium.
+         */
+        T2_MEDIUM("t2.medium"),
+        /**
+         * t2.large.
+         */
+        T2_LARGE("t2.large"),
+        /**
          * m2.xlarge.
          */
         M2_XLARGE("m2.xlarge"),
@@ -88,6 +144,34 @@ public abstract class AbstractMockEc2Instance implements Serializable {
          */
         M2_4XLARGE("m2.4xlarge"),
         /**
+         * cr1.8xlarge.
+         */
+        CR1_8XLARGE("cr1.8xlarge"),
+        /**
+         * i2.xlarge.
+         */
+        I2_XLARGE("i2.xlarge"),
+        /**
+         * i2.2xlarge.
+         */
+        I2_2XLARGE("i2.2xlarge"),
+        /**
+         * i2.4xlarge.
+         */
+        I2_4XLARGE("i2.4xlarge"),
+        /**
+         * i2.8xlarge.
+         */
+        I2_8XLARGE("i2.8xlarge"),
+        /**
+         * hi1.4xlarge.
+         */
+        HI1_4XLARGE("hi1.4xlarge"),
+        /**
+         * hs1.8xlarge.
+         */
+        HS1_8XLARGE("hs1.8xlarge"),
+        /**
          * c1.medium.
          */
         C1_MEDIUM("c1.medium"),
@@ -95,6 +179,46 @@ public abstract class AbstractMockEc2Instance implements Serializable {
          * c1.xlarge.
          */
         C1_XLARGE("c1.xlarge"),
+        /**
+         * c3.large.
+         */
+        C3_LARGE("c3.large"),
+        /**
+         * c3.xlarge.
+         */
+        C3_XLARGE("c3.xlarge"),
+        /**
+         * c3.2xlarge.
+         */
+        C3_2XLARGE("c3.2xlarge"),
+        /**
+         * c3.4xlarge.
+         */
+        C3_4XLARGE("c3.4xlarge"),
+        /**
+         * c3.8xlarge.
+         */
+        C3_8XLARGE("c3.8xlarge"),
+        /**
+         * c4.large.
+         */
+        C4_LARGE("c4.large"),
+        /**
+         * c4.xlarge.
+         */
+        C4_XLARGE("c4.xlarge"),
+        /**
+         * c4.2xlarge.
+         */
+        C4_2XLARGE("c4.2xlarge"),
+        /**
+         * c4.4xlarge.
+         */
+        C4_4XLARGE("c4.4xlarge"),
+        /**
+         * c4.8xlarge.
+         */
+        C4_8XLARGE("c4.8xlarge"),
         /**
          * cc1.4xlarge.
          */
@@ -104,13 +228,53 @@ public abstract class AbstractMockEc2Instance implements Serializable {
          */
         CC2_8XLARGE("cc2.8xlarge"),
         /**
+         * g2.2xlarge.
+         */
+        G2_2XLARGE("g2.2xlarge"),
+        /**
+         * g2.8xlarge.
+         */
+        G2_8XLARGE("g2.8xlarge"),
+        /**
          * cg1.4xlarge.
          */
         CG1_4XLARGE("cg1.4xlarge"),
         /**
-         * hi1.4xlarge.
+         * r3.large.
          */
-        HI1_4XLARGE("hi1.4xlarge");
+        R3_LARGE("r3.large"),
+        /**
+         * r3.xlarge.
+         */
+        R3_XLARGE("r3.xlarge"),
+        /**
+         * r3.2xlarge.
+         */
+        R3_2XLARGE("r3.2xlarge"),
+        /**
+         * r3.4xlarge.
+         */
+        R3_4XLARGE("r3.4xlarge"),
+        /**
+         * r3.8xlarge.
+         */
+        R3_8XLARGE("r3.8xlarge"),
+        /**
+         * d2.xlarge.
+         */
+        D2_XLARGE("d2.xlarge"),
+        /**
+         * d2.2xlarge.
+         */
+        D2_2XLARGE("d2.2xlarge"),
+        /**
+         * d2.4xlarge.
+         */
+        D2_4XLARGE("d2.4xlarge"),
+        /**
+         * d2.8xlarge.
+         */
+        D2_8XLARGE("d2.8xlarge");
 
         /**
          * Name of instacne type.

--- a/src/main/resources/aws-mock-default.properties
+++ b/src/main/resources/aws-mock-default.properties
@@ -36,3 +36,17 @@ persistence.enabled=false
 # point to the target file to which you would like to make runtime objects persistent
 persistence.store.file=/path/to/aws-mock.save
 
+# network related information
+network.vpcId=vpc-6e6eb509
+network.subnetId=subnet-0b763521
+network.privateIpAddress=172.31.55.149
+network.sourcePort=80
+network.destPort=80
+network.routeTableId=rtb-45c3e522
+network.internetGatewayId=igw-6bbde20f
+network.securityGroupId=sg-96e961ed
+network.securityOwnerId=391387808006
+network.securityGroupName=cell-manager-security-group
+network.ipProtocol=tcp
+network.vpcState=available
+network.cidrBlock=172.31.0.0/16

--- a/src/test/java/com/tlswe/awsmock/ec2/Ec2NetworkTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/Ec2NetworkTest.java
@@ -1,0 +1,91 @@
+/**
+ * File name: Ec2NetworkTest.java Author: Jiaqi Chen Create date: Jul 1,
+ * 2016
+ */
+package com.tlswe.awsmock.ec2;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.ec2.model.Vpc;
+import com.amazonaws.services.ec2.model.RouteTable;
+import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.amazonaws.services.ec2.model.InternetGateway;
+
+/**
+ * This test class covers some network related APIs test cases in aws-mock.
+ *
+ * @author Jiaqi Chen
+ */
+public class Ec2NetworkTest extends BaseTest {
+
+    /**
+     * 2 minutes timeout.
+     */
+    private static final int TIMEOUT_LEVEL1 = 120000;
+
+    /**
+     * Log writer for this class.
+     */
+    private static Logger log = LoggerFactory.getLogger(Ec2EndpointTest.class);
+
+    /**
+     * Test describing vpcs.
+     */
+    @Test(timeout = TIMEOUT_LEVEL1)
+    public final void describeVpcsTest() {
+        log.info("Start describing vpcs test");
+
+        List<Vpc> vpcs = describeVpcs();
+
+        Assert.assertNotNull("vpcs should not be null", vpcs);
+        Assert.assertNotNull("vpc id should not be null", vpcs.get(0).getVpcId());
+    }
+
+
+    /**
+     * Test describing security group.
+     */
+    @Test(timeout = TIMEOUT_LEVEL1)
+    public final void describeSecurityGroupTest() {
+        log.info("Start describing security group test");
+
+        SecurityGroup securityGroup = getSecurityGroup();
+
+        Assert.assertNotNull("security group should not be null", securityGroup);
+        Assert.assertNotNull("group id should not be null", securityGroup.getGroupId());
+        Assert.assertNotNull("vpc id should not be null", securityGroup.getVpcId());
+    }
+
+
+    /**
+     * Test describing internet gateway.
+     */
+    @Test(timeout = TIMEOUT_LEVEL1)
+    public final void describeInternetGatewayTest() {
+        log.info("Start describing internet gateway test");
+
+        InternetGateway internetGateway = getInternetGateway();
+
+        Assert.assertNotNull("internet gateway should not be null", internetGateway);
+        Assert.assertNotNull("internet gateway id should not be null", internetGateway.getInternetGatewayId());
+    }
+
+
+    /**
+     * Test describing route table.
+     */
+    @Test(timeout = TIMEOUT_LEVEL1)
+    public final void describeRouteTableTest() {
+        log.info("Start describing route table test");
+
+        RouteTable routeTable = getRouteTable();
+
+        Assert.assertNotNull("route table should not be null", routeTable);
+        Assert.assertNotNull("route table id should not be null", routeTable.getRouteTableId());
+    }
+}


### PR DESCRIPTION
Add four network related APIs, including:
 1. DescribeVpcs
 2. DescribeSecurityGroups
 3. DescribeInternetGateways
 4. DescribeRouteTables

Add state filter for describing instances. For example, to
get non terminated instances.

Add unit tests for the above new features.

Add all instance types from ec2 sdk.

Add Dockerfile for deploying in docker container.