### PR TITLE
Add describeAvailabilityZones and gradle.properties for jvm heap size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ coverage/
 .project
 .settings
 .gradle
-gradle.properties
+#gradle.properties
 
 # Generated Java stubs (with Apache-CXF)
 src/main/java/com/tlswe/awsmock/ec2/cxf_generated/*.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+[groovy]
+org.gradle.jvmargs= -Xmx4096m
+[/groovy]

--- a/src/integration-test/java/com/tlswe/awsmock/ec2/BaseTest.java
+++ b/src/integration-test/java/com/tlswe/awsmock/ec2/BaseTest.java
@@ -19,6 +19,9 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.AvailabilityZone;
+import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesRequest;
+import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesResult;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.DescribeInternetGatewaysRequest;
@@ -51,6 +54,7 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.amazonaws.services.ec2.model.TerminateInstancesResult;
 import com.amazonaws.services.ec2.model.Volume;
 import com.amazonaws.services.ec2.model.Vpc;
+import com.tlswe.awsmock.ec2.cxf_generated.AvailabilityZoneSetType;
 import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceState;
 import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
 
@@ -498,6 +502,22 @@ public class BaseTest {
         return routeTable;
     }
 
+    /**
+     * Describe AvailabilityZone.
+     *
+     * @return AvailabilityZone
+     */
+    protected final AvailabilityZone getAvailiablityZones() {
+        AvailabilityZone availabilityZone = null;
+
+        DescribeAvailabilityZonesResult result = amazonEC2Client.describeAvailabilityZones();
+        if (result != null && !result.getAvailabilityZones().isEmpty()) {
+            availabilityZone = result.getAvailabilityZones().get(0);
+        }
+
+        return availabilityZone;
+    }
+    
     /**
      * Describe Volume.
      *

--- a/src/integration-test/java/com/tlswe/awsmock/ec2/Ec2NetworkTest.java
+++ b/src/integration-test/java/com/tlswe/awsmock/ec2/Ec2NetworkTest.java
@@ -15,6 +15,7 @@ import com.amazonaws.services.ec2.model.Volume;
 import com.amazonaws.services.ec2.model.Vpc;
 import com.amazonaws.services.ec2.model.RouteTable;
 import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.amazonaws.services.ec2.model.AvailabilityZone;
 import com.amazonaws.services.ec2.model.InternetGateway;
 
 /**
@@ -88,6 +89,19 @@ public class Ec2NetworkTest extends BaseTest {
 
         Assert.assertNotNull("route table should not be null", routeTable);
         Assert.assertNotNull("route table id should not be null", routeTable.getRouteTableId());
+    }
+    
+    /**
+     * Test describing Availability Zones.
+     */
+    @Test(timeout = TIMEOUT_LEVEL1)
+    public final void describeAvailabilityZonesTest() {
+        log.info("Start describing Availability Zones test");
+
+        AvailabilityZone availabiltyZone = getAvailiablityZones();
+
+        Assert.assertNotNull("route table should not be null", availabiltyZone);
+        Assert.assertNotNull("route table id should not be null", availabiltyZone.getZoneName());
     }
     
     /**

--- a/src/main/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandler.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandler.java
@@ -26,6 +26,9 @@ import com.tlswe.awsmock.common.util.PropertiesUtils;
 import com.tlswe.awsmock.common.util.TemplateUtils;
 import com.tlswe.awsmock.ec2.cxf_generated.AttachmentSetItemResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.AttachmentSetResponseType;
+import com.tlswe.awsmock.ec2.cxf_generated.AvailabilityZoneItemType;
+import com.tlswe.awsmock.ec2.cxf_generated.AvailabilityZoneSetType;
+import com.tlswe.awsmock.ec2.cxf_generated.DescribeAvailabilityZonesResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseInfoType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseItemType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseType;
@@ -334,9 +337,7 @@ public final class MockEC2QueryHandler {
             // do nothing in case null is passed in
             return;
         }
-
         String responseXml = null;
-
         if (null == queryParams || queryParams.size() == 0) {
             // no params found at all - write an error xml response
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -446,6 +447,9 @@ public final class MockEC2QueryHandler {
                             } else if ("DescribeSubnets".equals(action)) {
                                 responseXml = JAXBUtil.marshall(describeSubnets(),
                                     "DescribeSubnetsResponseType", version);
+                            } else if ("DescribeAvailabilityZones".equals(action)) {
+                                responseXml = JAXBUtil.marshall(describeAvailabilityZones(),
+                                        "DescribeAvailabilityZonesResponseType", version);
                             } else {
                                 // unsupported/unimplemented action - write an
                                 // error
@@ -471,12 +475,9 @@ public final class MockEC2QueryHandler {
 
                 }
             }
-
         }
-
         response.getWriter().write(responseXml);
         response.getWriter().flush();
-
     }
 
 
@@ -499,6 +500,27 @@ public final class MockEC2QueryHandler {
             }
         }
         return instanceStates;
+    }
+
+    /**
+     * Handles "describeAvailabilityZones" request, as simple as without any filters to use.
+     *
+     * @return a DescribeAvailabilityZonesResponseType with our predefined AMIs
+     * in aws-mock.properties (or if not overridden, as defined in aws-mock-default.properties)
+     */
+    private DescribeAvailabilityZonesResponseType describeAvailabilityZones() {
+        DescribeAvailabilityZonesResponseType ret = new DescribeAvailabilityZonesResponseType();
+        ret.setRequestId(UUID.randomUUID().toString());
+
+        AvailabilityZoneSetType info = new AvailabilityZoneSetType();
+
+        AvailabilityZoneItemType item = new AvailabilityZoneItemType();
+        item.setRegionName(DEFAULT_MOCK_PLACEMENT.getAvailabilityZone());
+        item.setZoneName(DEFAULT_MOCK_PLACEMENT.getAvailabilityZone());
+
+        info.getItem().add(item);
+        ret.setAvailabilityZoneInfo(info);
+        return ret;
     }
 
 

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandlerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandlerTest.java
@@ -29,6 +29,8 @@ import org.powermock.reflect.Whitebox;
 
 import com.tlswe.awsmock.common.util.Constants;
 import com.tlswe.awsmock.common.util.PropertiesUtils;
+import com.tlswe.awsmock.ec2.cxf_generated.AvailabilityZoneItemType;
+import com.tlswe.awsmock.ec2.cxf_generated.DescribeAvailabilityZonesResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseInfoType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseItemType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseType;
@@ -200,6 +202,18 @@ public class MockEC2QueryHandlerTest {
 
     }
 
+    @Test
+    public void Test_describeAvailabilityZones() throws Exception {
+        MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
+        DescribeAvailabilityZonesResponseType describeAvailabilityZonesResponseType = Whitebox.invokeMethod(handler,
+                "describeAvailabilityZones");
+
+        Assert.assertTrue(describeAvailabilityZonesResponseType != null);
+        Assert.assertTrue(describeAvailabilityZonesResponseType.getAvailabilityZoneInfo().getItem().size() == 1);
+
+        AvailabilityZoneItemType availabilityZoneItemType = describeAvailabilityZonesResponseType.getAvailabilityZoneInfo().getItem().get(0);
+        Assert.assertTrue(availabilityZoneItemType.getRegionName() != null);
+    }
 
     @Test
     public void Test_describeImages() throws Exception {
@@ -885,6 +899,30 @@ public class MockEC2QueryHandlerTest {
 
         queryParams.put(VERSION_KEY, new String[] { VERSION_1 });
         queryParams.put(ACTION_KEY, new String[] { "DescribeVolumes" });
+
+        handler.handle(queryParams, response);
+
+        String responseString = sw.toString();
+        Assert.assertTrue(responseString.equals(DUMMY_XML_RESPONSE));
+    }
+    
+    @Test
+    public void Test_handleDescribeAvailabilityZones() throws IOException {
+
+        HttpServletResponse response = Mockito.spy(HttpServletResponse.class);
+        MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        Mockito.when(response.getWriter()).thenReturn(pw);
+        Mockito.when(JAXBUtil.marshall(Mockito.any(), Mockito.eq("DescribeAvailabilityZonesResponseType"), Mockito.eq(VERSION_1)))
+                .thenReturn(DUMMY_XML_RESPONSE);
+
+        Map<String, String[]> queryParams = new HashMap<String, String[]>();
+
+        queryParams.put(VERSION_KEY, new String[] { VERSION_1 });
+        queryParams.put(ACTION_KEY, new String[] { "DescribeAvailabilityZones" });
 
         handler.handle(queryParams, response);
 


### PR DESCRIPTION
Add describeAvailabilityZones and gradle.properties for jvm heap size. 

For large number of instances: jetty failed. Do you have fix that? By Adding the gradle jvm heap size helped little. However, still, it is still failing large numbers of instances