### PR TITLE
Add support for storing subnet id in ec2instance and report vpc for stored subnet id in describeInstances

### DIFF
--- a/src/main/java/com/tlswe/awsmock/ec2/control/MockEc2Controller.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/control/MockEc2Controller.java
@@ -146,12 +146,15 @@ public final class MockEc2Controller {
      *            max count of instances to run (but limited to {@link #MAX_RUN_INSTANCE_COUNT_AT_A_TIME})
      * @param maxCount
      *            min count of instances to run (should larger than 0)
+     * @param subnetId
+     *            The subnet id of new mock ec2 instance(s). May be null.
+     *
      * @return a list of objects of clazz as started new mock ec2 instances
      *
      */
     public <T extends AbstractMockEc2Instance> List<T> runInstances(final Class<? extends T> clazz,
             final String imageId, final String instanceTypeName,
-            final int minCount, final int maxCount) {
+            final int minCount, final int maxCount, final String subnetId) {
 
         // EC2 Query Request action name
         final String action = "runInstances";
@@ -202,6 +205,7 @@ public final class MockEc2Controller {
             inst.setImageId(imageId);
             inst.setInstanceType(instanceType);
             // inst.setSecurityGroups(securityGroups);
+            inst.setSubnetId(subnetId);
 
             inst.start();
 

--- a/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/model/AbstractMockEc2Instance.java
@@ -534,6 +534,11 @@ public abstract class AbstractMockEc2Instance implements Serializable {
     private Set<String> securityGroups = new TreeSet<String>();
 
     /**
+     * Subnet id for this ec2 instance.
+     */
+    private String subnetId = null;
+
+    /**
      * Flag that indicates whether internal timer of this mock ec2 instance has been started (on instance start()).
      */
     private boolean internalTimerInitialized = false;
@@ -798,6 +803,24 @@ public abstract class AbstractMockEc2Instance implements Serializable {
                         : (isStopping() ? InstanceState.STOPPING
                                 : (isRunning() ? InstanceState.RUNNING
                                         : InstanceState.STOPPED)));
+    }
+
+    /**
+     * Get subnet ID of this mock ec2 instance.
+     *
+     * @return subnet ID of this mock ec2 instance
+     */
+    public final String getSubnetId() {
+        return subnetId;
+    }
+
+    /**
+     * Set the subnet ID of this mock ec2 instance.
+     *
+     * @param subnetId subnet ID of this mock ec2 instance
+     */
+    public void setSubnetId(final String subnetId) {
+        this.subnetId = subnetId;
     }
 
     /**

--- a/src/main/java/com/tlswe/awsmock/ec2/model/DefaultMockEc2Instance.java
+++ b/src/main/java/com/tlswe/awsmock/ec2/model/DefaultMockEc2Instance.java
@@ -15,7 +15,7 @@ public class DefaultMockEc2Instance extends AbstractMockEc2Instance {
      *
      * @see Serializable
      */
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     @Override
     public void onStarted() {

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandlerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandlerTest.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpServletResponse;
 
+import com.tlswe.awsmock.ec2.model.MockSubnet;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,12 +59,10 @@ import com.tlswe.awsmock.ec2.cxf_generated.DescribeTagsResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeVolumesResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.DescribeVpcsResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.InternetGatewayType;
-import com.tlswe.awsmock.ec2.cxf_generated.IpPermissionType;
 import com.tlswe.awsmock.ec2.cxf_generated.ReservationInfoType;
 import com.tlswe.awsmock.ec2.cxf_generated.RunInstancesResponseType;
 import com.tlswe.awsmock.ec2.cxf_generated.RunningInstancesItemType;
 import com.tlswe.awsmock.ec2.cxf_generated.RunningInstancesSetType;
-import com.tlswe.awsmock.ec2.cxf_generated.SecurityGroupItemType;
 import com.tlswe.awsmock.ec2.cxf_generated.VpcType;
 import com.tlswe.awsmock.ec2.exception.BadEc2RequestException;
 import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
@@ -86,6 +86,8 @@ public class MockEC2QueryHandlerTest {
     private static final String ACTION_KEY = "Action";
     private static final String VERSION_KEY = "Version";
     private static final String VERSION_1 = "version1";
+    private static final String SUBNET_ID = "subnetId";
+    private static final String VPC_ID = "vpcId";
 
     static {
         InputStream inputStream = null;
@@ -510,17 +512,18 @@ public class MockEC2QueryHandlerTest {
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
         Whitebox.setInternalState(handler, "mockEc2Controller", controller);
 
+        createAndInjectMockSubnetController(handler);
+
         RunInstancesResponseType ret = Whitebox.invokeMethod(handler, "runInstances", "ami-1",
-                InstanceType.C1_MEDIUM.getName(), 1, 1);
+                InstanceType.C1_MEDIUM.getName(), 1, 1, SUBNET_ID);
 
         Assert.assertTrue(ret != null);
         Assert.assertTrue(ret.getInstancesSet().getItem().size() == 1);
 
         RunningInstancesItemType instItem = ret.getInstancesSet().getItem().get(0);
-        Assert.assertTrue(instItem.getVpcId().equals(properties.get(Constants.PROP_NAME_VPC_ID))); // from
-                                                                                                   // aws.mock-default.properties
+        Assert.assertTrue(instItem.getVpcId().equals(VPC_ID));
         Assert.assertTrue(
-                instItem.getSubnetId().equals(properties.get(Constants.PROP_NAME_SUBNET_ID)));
+                instItem.getSubnetId().equals(SUBNET_ID));
         Assert.assertTrue(instItem.getPrivateIpAddress()
                 .equals(properties.get(Constants.PROP_NAME_PRIVATE_IP_ADDRESS)));
         Assert.assertTrue(instItem.getImageId().equals("ami-1"));
@@ -713,9 +716,11 @@ public class MockEC2QueryHandlerTest {
 
         CustomMockEc2Instance ec2Mocked1 = new CustomMockEc2Instance();
         ec2Mocked1.setInstanceType(InstanceType.C1_MEDIUM);
+        ec2Mocked1.setSubnetId(SUBNET_ID);
 
         CustomMockEc2Instance ec2Mocked2 = new CustomMockEc2Instance();
         ec2Mocked2.setInstanceType(InstanceType.C3_8XLARGE);
+        ec2Mocked2.setSubnetId(SUBNET_ID);
 
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
 
@@ -730,6 +735,8 @@ public class MockEC2QueryHandlerTest {
         MemberModifier.field(MockEc2Controller.class, "allMockEc2Instances").set(controller,
                 allMockEc2Instances);
         Whitebox.setInternalState(handler, "mockEc2Controller", controller);
+
+        createAndInjectMockSubnetController(handler);
 
         Set<String> instanceStateSet = new HashSet<String>();
         instanceStateSet.add(InstanceState.STOPPED.getName());
@@ -758,13 +765,15 @@ public class MockEC2QueryHandlerTest {
 
         String instanceId1 = runningSetType.getItem().get(0).getInstanceId();
 
-        // check if default params were applied
+        // check if network params were applied
         Assert.assertTrue(runningSetType.getItem().get(0).getVpcId()
-                .equals(properties.get(Constants.PROP_NAME_VPC_ID)));
+                .equals(VPC_ID));
+        Assert.assertTrue(runningSetType.getItem().get(0).getSubnetId()
+                .equals(SUBNET_ID));
+
+        // check if default params were applied
         Assert.assertTrue(runningSetType.getItem().get(0).getPrivateIpAddress()
                 .equals(properties.get(Constants.PROP_NAME_PRIVATE_IP_ADDRESS)));
-        Assert.assertTrue(runningSetType.getItem().get(0).getSubnetId()
-                .equals(properties.get(Constants.PROP_NAME_SUBNET_ID)));
         Assert.assertTrue(runningSetType.getItem().get(0).getInstanceState().getName()
                 .equals(InstanceState.STOPPED.getName()));
 
@@ -772,13 +781,15 @@ public class MockEC2QueryHandlerTest {
 
         String instanceId2 = runningSetType.getItem().get(0).getInstanceId();
 
-        // check if default params were applied
+        // check if network params were applied
         Assert.assertTrue(runningSetType.getItem().get(0).getVpcId()
-                .equals(properties.get(Constants.PROP_NAME_VPC_ID)));
+                .equals(VPC_ID));
+        Assert.assertTrue(runningSetType.getItem().get(0).getSubnetId()
+                .equals(SUBNET_ID));
+
+        // check if default params were applied
         Assert.assertTrue(runningSetType.getItem().get(0).getPrivateIpAddress()
                 .equals(properties.get(Constants.PROP_NAME_PRIVATE_IP_ADDRESS)));
-        Assert.assertTrue(runningSetType.getItem().get(0).getSubnetId()
-                .equals(properties.get(Constants.PROP_NAME_SUBNET_ID)));
         Assert.assertTrue(runningSetType.getItem().get(0).getInstanceState().getName()
                 .equals(InstanceState.STOPPED.getName()));
 
@@ -1100,6 +1111,35 @@ public class MockEC2QueryHandlerTest {
         queryParams.put("MinCount", new String[] { "2" });
         queryParams.put("MaxCount", new String[] { "5" });
         queryParams.put("InstanceType", new String[] { "m1.small" });
+        handler.handle(queryParams, null, response);
+
+        String responseString = sw.toString();
+        Assert.assertTrue(responseString.equals(DUMMY_XML_RESPONSE));
+    }
+
+    @Test
+    public void Test_handleRunInstancesWithSubnetId() throws IOException {
+
+        HttpServletResponse response = Mockito.spy(HttpServletResponse.class);
+        MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        Mockito.when(response.getWriter()).thenReturn(pw);
+        Mockito.when(JAXBUtil.marshall(Mockito.any(), Mockito.eq("RunInstancesResponse"),
+                Mockito.eq(VERSION_1)))
+                .thenReturn(DUMMY_XML_RESPONSE);
+
+        Map<String, String[]> queryParams = new HashMap<String, String[]>();
+
+        queryParams.put(VERSION_KEY, new String[] { VERSION_1 });
+        queryParams.put(ACTION_KEY, new String[] { "RunInstances" });
+        queryParams.put("ImageId", new String[] { "img-1" });
+        queryParams.put("MinCount", new String[] { "2" });
+        queryParams.put("MaxCount", new String[] { "5" });
+        queryParams.put("InstanceType", new String[] { "m1.small" });
+        queryParams.put("SubnetId", new String[] { "subnetId" });
         handler.handle(queryParams, null, response);
 
         String responseString = sw.toString();
@@ -2314,5 +2354,15 @@ public class MockEC2QueryHandlerTest {
 
         String responseString = sw.toString();
         Assert.assertTrue(responseString.contains("Response"));
+    }
+
+    private static void createAndInjectMockSubnetController(final MockEC2QueryHandler handler) {
+        final MockSubnet subnet = new MockSubnet();
+        subnet.setSubnetId(SUBNET_ID);
+        subnet.setVpcId(VPC_ID);
+
+        MockSubnetController subnetControllerMock = Mockito.spy(MockSubnetController.class);
+        Mockito.when(subnetControllerMock.describeSubnets()).thenReturn(Collections.singletonList(subnet));
+        Whitebox.setInternalState(handler, "mockSubnetController", subnetControllerMock);
     }
 }

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockEc2ControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockEc2ControllerTest.java
@@ -27,6 +27,7 @@ import com.tlswe.awsmock.ec2.model.DefaultMockEc2Instance;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockEc2Controller.class, DefaultMockEc2Instance.class })
 public class MockEc2ControllerTest {
+    private static final String SUBNET_ID = "SubnetId";
 
     @Test
     public void Test_getInstance() {
@@ -375,7 +376,7 @@ public class MockEc2ControllerTest {
     public void Test_runInstancesBadRequestInstanceType() throws Exception {
 
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
-        controller.runInstances(DefaultMockEc2Instance.class, "ImageName", "InvalidName", 10, 1);
+        controller.runInstances(DefaultMockEc2Instance.class, "ImageName", "InvalidName", 10, 1, SUBNET_ID);
     }
 
     @Test(expected = BadEc2RequestException.class)
@@ -383,7 +384,7 @@ public class MockEc2ControllerTest {
 
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
         controller.runInstances(DefaultMockEc2Instance.class, "ImageName",
-                InstanceType.C1_MEDIUM.getName(), 1, 10001);
+                InstanceType.C1_MEDIUM.getName(), 1, 10001, SUBNET_ID);
     }
 
     @Test(expected = BadEc2RequestException.class)
@@ -391,7 +392,7 @@ public class MockEc2ControllerTest {
 
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
         controller.runInstances(DefaultMockEc2Instance.class, "ImageName",
-                InstanceType.C1_MEDIUM.getName(), 0, 10);
+                InstanceType.C1_MEDIUM.getName(), 0, 10, SUBNET_ID);
     }
 
     @Test(expected = BadEc2RequestException.class)
@@ -399,7 +400,7 @@ public class MockEc2ControllerTest {
 
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
         controller.runInstances(DefaultMockEc2Instance.class, "ImageName",
-                InstanceType.C1_MEDIUM.getName(), 11, 10);
+                InstanceType.C1_MEDIUM.getName(), 11, 10, SUBNET_ID);
     }
 
     @Test(expected = AwsMockException.class)
@@ -409,7 +410,7 @@ public class MockEc2ControllerTest {
 
         // shouldn't be able to start abstract class
         controller.runInstances(AbstractMockEc2Instance.class, "ImageName",
-                InstanceType.C1_MEDIUM.getName(), 1, 1);
+                InstanceType.C1_MEDIUM.getName(), 1, 1, SUBNET_ID);
     }
 
     @Test
@@ -417,7 +418,7 @@ public class MockEc2ControllerTest {
 
         MockEc2Controller controller = Mockito.spy(MockEc2Controller.class);
         controller.runInstances(DefaultMockEc2Instance.class, "ImageName",
-                InstanceType.C1_MEDIUM.getName(), 1, 1);
+                InstanceType.C1_MEDIUM.getName(), 1, 1, SUBNET_ID);
     }
 
 }

--- a/src/test/java/com/tlswe/awsmock/ec2/util/JAXBUtilTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/util/JAXBUtilTest.java
@@ -19,6 +19,7 @@ import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockEC2QueryHandler.class, PropertiesUtils.class })
 public class JAXBUtilTest {
+    private static final String SUBNET_ID = "subnetId";
 
     @Test
     public void Test_marshall() throws Exception {
@@ -31,7 +32,7 @@ public class JAXBUtilTest {
         MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
         RunInstancesResponseType runInstancesResponseType = Whitebox.invokeMethod(handler,
                 "runInstances", imageID,
-                instanceType, minCount, maxCount);
+                instanceType, minCount, maxCount, SUBNET_ID);
 
         String xml = JAXBUtil.marshall(runInstancesResponseType, "RunInstancesResponse",
                 "2012-02-10");
@@ -65,7 +66,7 @@ public class JAXBUtilTest {
         MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
         RunInstancesResponseType runInstancesResponseType = Whitebox.invokeMethod(handler,
                 "runInstances", imageID,
-                instanceType, minCount, maxCount);
+                instanceType, minCount, maxCount, SUBNET_ID);
 
         String xml = JAXBUtil.marshall(runInstancesResponseType, "RunInstancesResponse", null);
 
@@ -89,7 +90,7 @@ public class JAXBUtilTest {
         MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
         RunInstancesResponseType runInstancesResponseType = Whitebox.invokeMethod(handler,
                 "runInstances", imageID,
-                instanceType, minCount, maxCount);
+                instanceType, minCount, maxCount, SUBNET_ID);
 
         String xml = JAXBUtil.marshall(runInstancesResponseType, "RunInstancesResponse", null);
 
@@ -109,7 +110,7 @@ public class JAXBUtilTest {
         MockEC2QueryHandler handler = MockEC2QueryHandler.getInstance();
         RunInstancesResponseType runInstancesResponseType = Whitebox.invokeMethod(handler,
                 "runInstances", imageID,
-                instanceType, minCount, maxCount);
+                instanceType, minCount, maxCount, SUBNET_ID);
 
         String xml = JAXBUtil.marshall(runInstancesResponseType, "RunInstancesResponse",
                 PropertiesUtils


### PR DESCRIPTION
Add support for persisting subnet id. The subnet id is also used to derive the vpc id. 
Previously the default subnet id and vpc id were returned for all instances. 