### PR TITLE
Cbalz fix starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Inside aws-mock, the mock EC2 instances can work in their own program threads an
 
 For more information, please refer to the [Technical Specifications](https://github.com/treelogic-swe/aws-mock/wiki/Technical-Specifications).
 
+## Prerequisites
+
+Java 8 . For example: `export JAVA_HOME=$(/usr/libexec/java_home -v1.8)`
+
 ## Quick Start
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 allprojects {
     repositories {
-        maven { url 'http://repo2.maven.org/maven2/' }
+        maven { url 'https://repo1.maven.org/maven2/' }
     }
 }
 
 buildscript {
     repositories {
-        maven { url 'http://repo2.maven.org/maven2/' }
+        maven { url 'https://repo1.maven.org/maven2/' }
     }
     dependencies {
         classpath "net.saliman:gradle-cobertura-plugin:2.3.2"


### PR DESCRIPTION
On a fresh machine, aws-mock would not work out of the box.  It needed a couple fixes due to changes in Java and Maven.  This pr does those.  