### PR TITLE
Fix cxf build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,9 @@ dependencies {
     compile "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
     compile "org.glassfish.jaxb:jaxb-runtime:2.3.2"
     testCompile "com.amazonaws:aws-java-sdk:1.11.52"
-    testCompile "org.powermock:powermock:1.6.5"
-    testCompile "org.powermock:powermock-module-junit4:1.6.5"
-    testCompile "org.powermock:powermock-api-mockito:1.6.5"
+    testCompile "org.powermock:powermock-core:2.0.9"
+    testCompile "org.powermock:powermock-module-junit4:2.0.9"
+    testCompile "org.powermock:powermock-api-mockito2:2.0.9"
 
     def tomcatVersion = '7.0.92'
     tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",

--- a/cxf-stub/build.gradle
+++ b/cxf-stub/build.gradle
@@ -10,7 +10,6 @@ def ec2ApiVersion = "ec2-2014-02-01"
 def stubJarFilename = "cxf-stub-" + ec2ApiVersion + ".jar"
 
 def cloudwatchApiVersion = "cloudwatch-2010-08-01"
-//def stubCWJarFilename = "cxf-stub-" + cloudwatchApiVersion + ".jar"
 
 configurations.all {
     // check for updates every build
@@ -31,14 +30,15 @@ ext {
 
 dependencies {
     cxfArtifacts.each { artifact -> cxf "org.apache.cxf:$artifact:$cxfVersion" }
+    runtime "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
+    runtime "org.glassfish.jaxb:jaxb-runtime:2.3.2"
 }
 
 task wsdl2java (type: JavaExec) {
     inputs.file file('ec2-2014-02-01.wsdl')
     outputs.dir new File('build', 'stub_src')
-
-	main = 'org.apache.cxf.tools.wsdlto.WSDLToJava'
-    //classpath = sourceSets.main.runtimeClasspath
+    
+    main = 'org.apache.cxf.tools.wsdlto.WSDLToJava'
     classpath = configurations.cxf
     args = [ "-quiet", "-d", "build/stub_src", "-p", "com.tlswe.awsmock.ec2.cxf_generated", "-autoNameResolution", "-impl", "-server", "-frontend", "jaxws21", ec2ApiVersion+".wsdl" ]
 }
@@ -47,8 +47,7 @@ task cloudwatchwsdl2java (type: JavaExec) {
     inputs.file file('cloudwatch-2010-08-01.wsdl')
     outputs.dir new File('build', 'stub_src')
 
-	main = 'org.apache.cxf.tools.wsdlto.WSDLToJava'
-    //classpath = sourceSets.main.runtimeClasspath
+    main = 'org.apache.cxf.tools.wsdlto.WSDLToJava'
     classpath = configurations.cxf
     args = [ "-quiet", "-d", "build/stub_src", "-p", "com.tlswe.awsmock.cloudwatch.cxf_generated", "-autoNameResolution", "-impl", "-server", "-frontend", "jaxws21", cloudwatchApiVersion+".wsdl" ]
 }
@@ -70,11 +69,8 @@ compileJava {
 
 jar {
     inputs.dir new File('build', 'stub_classes')
-    //outputs.file file('../libs/' + stubJarFilename)
-    //archiveName = stubJarFilename
     manifest.attributes provider: 'tlswe'
     from 'build/stub_classes' // ,'build/stub_src'
-    //destinationDir = file('../libs')
 }
 
 javadoc {
@@ -82,9 +78,6 @@ javadoc {
     // source 'build/stub_src'
 }
 
-//task cxfStubJarClean (type: Delete) {
-//    delete '../libs/' + stubJarFilename
-//}
 
 task sourcesJar(type:Jar){
     classifier = 'sources'

--- a/cxf-stub/build.gradle
+++ b/cxf-stub/build.gradle
@@ -48,7 +48,7 @@ task cloudwatchwsdl2java (type: JavaExec) {
     outputs.dir new File('build', 'stub_src')
 
     main = 'org.apache.cxf.tools.wsdlto.WSDLToJava'
-    classpath = configurations.cxf
+    classpath = configurations.cxf + configurations.runtimeClasspath
     args = [ "-quiet", "-d", "build/stub_src", "-p", "com.tlswe.awsmock.cloudwatch.cxf_generated", "-autoNameResolution", "-impl", "-server", "-frontend", "jaxws21", cloudwatchApiVersion+".wsdl" ]
 }
 

--- a/cxf-stub/build.gradle
+++ b/cxf-stub/build.gradle
@@ -30,8 +30,7 @@ ext {
 
 dependencies {
     cxfArtifacts.each { artifact -> cxf "org.apache.cxf:$artifact:$cxfVersion" }
-    runtime "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
-    runtime "org.glassfish.jaxb:jaxb-runtime:2.3.2"
+    runtime 'javax.xml.ws:jaxws-api:2.2.6'
 }
 
 task wsdl2java (type: JavaExec) {
@@ -39,7 +38,7 @@ task wsdl2java (type: JavaExec) {
     outputs.dir new File('build', 'stub_src')
     
     main = 'org.apache.cxf.tools.wsdlto.WSDLToJava'
-    classpath = configurations.cxf
+    classpath = configurations.cxf + configurations.runtimeClasspath
     args = [ "-quiet", "-d", "build/stub_src", "-p", "com.tlswe.awsmock.ec2.cxf_generated", "-autoNameResolution", "-impl", "-server", "-frontend", "jaxws21", ec2ApiVersion+".wsdl" ]
 }
 
@@ -60,8 +59,8 @@ compileJava {
     dependsOn wsdl2java, cloudwatchwsdl2java
     inputs.dir new File('build', 'stub_src')
     outputs.dir new File('build', 'stub_classes')
-    sourceCompatibility = '1.6'
-    targetCompatibility = '1.6'
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
     classpath = configurations.runtime
     source = file ('build/stub_src')
     destinationDir = file ('build/stub_classes')
@@ -78,6 +77,9 @@ javadoc {
     // source 'build/stub_src'
 }
 
+//task cxfStubJarClean (type: Delete) {
+//    delete '../libs/' + stubJarFilename
+//}
 
 task sourcesJar(type:Jar){
     classifier = 'sources'
@@ -153,12 +155,17 @@ uploadArchives {
                     developer {
                         id 'Jayscrivner'
                         name 'Jay Scrivner'
-			email 'Jayscrivner@gmail.com'
+                        email 'Jayscrivner@gmail.com'
                     }
                     developer {
                         id 'lhcxx'
                         name 'Lu Huichun'
                         email 'lhcxx0508@gmail.com'
+                    }
+                    developer {
+                        id 'zkareem'
+                        name 'Zaki Kareem'
+                        email 'zakimak9@gmail.com'
                     }
                }
             }

--- a/src/test/java/com/tlswe/awsmock/cloudwatch/control/MockCloudWatchQueryHandlerTest.java
+++ b/src/test/java/com/tlswe/awsmock/cloudwatch/control/MockCloudWatchQueryHandlerTest.java
@@ -1,16 +1,11 @@
 package com.tlswe.awsmock.cloudwatch.control;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.xml.datatype.XMLGregorianCalendar;
-
+import com.tlswe.awsmock.cloudwatch.cxf_generated.DescribeAlarmsResponse;
+import com.tlswe.awsmock.cloudwatch.cxf_generated.GetMetricStatisticsResponse;
+import com.tlswe.awsmock.cloudwatch.cxf_generated.StandardUnit;
+import com.tlswe.awsmock.cloudwatch.util.JAXBUtilCW;
+import com.tlswe.awsmock.common.util.Constants;
+import com.tlswe.awsmock.common.util.PropertiesUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Assert;
@@ -19,21 +14,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import com.tlswe.awsmock.cloudwatch.cxf_generated.StandardUnit;
-import com.tlswe.awsmock.cloudwatch.cxf_generated.DescribeAlarmsResponse;
-import com.tlswe.awsmock.cloudwatch.cxf_generated.GetMetricStatisticsResponse;
-import com.tlswe.awsmock.cloudwatch.util.JAXBUtilCW;
-import com.tlswe.awsmock.common.util.Constants;
-import com.tlswe.awsmock.common.util.PropertiesUtils;
-import com.tlswe.awsmock.ec2.control.MockEC2QueryHandler;
-import com.tlswe.awsmock.ec2.util.JAXBUtil;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockCloudWatchQueryHandler.class, JAXBUtilCW.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockCloudWatchQueryHandlerTest {
 
     private static Properties properties = new Properties();

--- a/src/test/java/com/tlswe/awsmock/cloudwatch/servlet/MockCloudWatchEndpointServletTest.java
+++ b/src/test/java/com/tlswe/awsmock/cloudwatch/servlet/MockCloudWatchEndpointServletTest.java
@@ -1,29 +1,28 @@
 package com.tlswe.awsmock.cloudwatch.servlet;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Vector;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.tlswe.awsmock.cloudwatch.control.MockCloudWatchQueryHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.cloudwatch.control.MockCloudWatchQueryHandler;
-import com.tlswe.awsmock.ec2.control.MockEC2QueryHandler;
-import com.tlswe.awsmock.ec2.servlet.MockEc2EndpointServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockCloudWatchQueryHandler.class, HttpServletRequest.class,
         HttpServletResponse.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockCloudWatchEndpointServletTest {
 
     @Mock

--- a/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
+++ b/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
@@ -18,6 +18,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.Writer;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockCloudWatchQueryHandler.class, PropertiesUtils.class })
@@ -155,16 +157,25 @@ public class JAXBUtilCWTest {
     @Test(expected = AwsMockException.class)
     public void Test_marshallGetMetricStatisticsFailed() throws Exception {
         PowerMockito.spy(PropertiesUtils.class);
-        Mockito.when(PropertiesUtils.getProperty(Constants.PROP_NAME_CLOUDWATCH_XMLNS_CURRENT))
-                .thenThrow(JAXBException.class);
-        JAXBUtilCW.marshall(new GetMetricStatisticsResponse(), "Test", "2012-02-10");
+        GetMetricStatisticsResponse getMetricStatisticsResponse = new GetMetricStatisticsResponse();
+
+        Marshaller jaxbMarshaller = Mockito.mock(Marshaller.class);
+        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", jaxbMarshaller);
+
+        Mockito.doThrow(new JAXBException("")).when(jaxbMarshaller).marshal(Mockito.any(), Mockito.any(Writer.class));
+
+        JAXBUtilCW.marshall(getMetricStatisticsResponse, "Test", "2012-02-10");
     }
 
     @Test(expected = AwsMockException.class)
     public void Test_marshallDescribeAlarmsFailed() throws Exception {
         PowerMockito.spy(PropertiesUtils.class);
-        Mockito.when(PropertiesUtils.getProperty(Constants.PROP_NAME_CLOUDWATCH_XMLNS_CURRENT))
-                .thenThrow(JAXBException.class);
+
+        Marshaller jaxbMarshaller = Mockito.mock(Marshaller.class);
+        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", jaxbMarshaller);
+
+        Mockito.doThrow(new JAXBException("")).when(jaxbMarshaller).marshal(Mockito.any(), Mockito.any(Writer.class));
+
         JAXBUtilCW.marshall(new DescribeAlarmsResponse(), "Test", "2012-02-10");
     }
 }

--- a/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
+++ b/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
@@ -3,7 +3,6 @@ package com.tlswe.awsmock.cloudwatch.util;
 import com.tlswe.awsmock.cloudwatch.control.MockCloudWatchQueryHandler;
 import com.tlswe.awsmock.cloudwatch.cxf_generated.DescribeAlarmsResponse;
 import com.tlswe.awsmock.cloudwatch.cxf_generated.GetMetricStatisticsResponse;
-import com.tlswe.awsmock.common.exception.AwsMockException;
 import com.tlswe.awsmock.common.util.Constants;
 import com.tlswe.awsmock.common.util.PropertiesUtils;
 import org.joda.time.DateTime;
@@ -16,11 +15,6 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import java.io.Writer;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockCloudWatchQueryHandler.class, PropertiesUtils.class })
@@ -153,41 +147,5 @@ public class JAXBUtilCWTest {
                 .getProperty(Constants.PROP_NAME_CLOUDWATCH_API_VERSION_CURRENT_IMPL));
 
         Assert.assertTrue(xml != null && !xml.isEmpty());
-    }
-
-    @Test(expected = AwsMockException.class)
-    public void Test_marshallGetMetricStatisticsFailed() throws Exception {
-
-        GetMetricStatisticsResponse getMetricStatisticsResponse = new GetMetricStatisticsResponse();
-
-        Marshaller jaxbMarshaller = Mockito.mock(Marshaller.class);
-        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", jaxbMarshaller);
-
-        Mockito.doThrow(new JAXBException("")).when(jaxbMarshaller).marshal(Mockito.any(), Mockito.any(Writer.class));
-
-        JAXBUtilCW.marshall(getMetricStatisticsResponse, "Test", "2012-02-10");
-        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", getMarshaller());
-    }
-
-    @Test(expected = AwsMockException.class)
-    public void Test_marshallDescribeAlarmsFailed() throws Exception {
-
-        Marshaller jaxbMarshaller = Mockito.mock(Marshaller.class);
-        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", jaxbMarshaller);
-
-        Mockito.doThrow(new JAXBException("")).when(jaxbMarshaller).marshal(Mockito.any(), Mockito.any(Writer.class));
-
-        JAXBUtilCW.marshall(new DescribeAlarmsResponse(), "Test", "2012-02-10");
-        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", getMarshaller());
-    }
-
-    public Marshaller getMarshaller() throws JAXBException {
-        JAXBContext jaxbContext = JAXBContext.newInstance("com.tlswe.awsmock.cloudwatch.cxf_generated");
-        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-
-        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-        jaxbMarshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
-
-        return jaxbMarshaller;
     }
 }

--- a/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
+++ b/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
@@ -17,6 +17,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
+import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import java.io.Writer;
@@ -156,7 +157,7 @@ public class JAXBUtilCWTest {
 
     @Test(expected = AwsMockException.class)
     public void Test_marshallGetMetricStatisticsFailed() throws Exception {
-        PowerMockito.spy(PropertiesUtils.class);
+
         GetMetricStatisticsResponse getMetricStatisticsResponse = new GetMetricStatisticsResponse();
 
         Marshaller jaxbMarshaller = Mockito.mock(Marshaller.class);
@@ -165,11 +166,11 @@ public class JAXBUtilCWTest {
         Mockito.doThrow(new JAXBException("")).when(jaxbMarshaller).marshal(Mockito.any(), Mockito.any(Writer.class));
 
         JAXBUtilCW.marshall(getMetricStatisticsResponse, "Test", "2012-02-10");
+        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", getMarshaller());
     }
 
     @Test(expected = AwsMockException.class)
     public void Test_marshallDescribeAlarmsFailed() throws Exception {
-        PowerMockito.spy(PropertiesUtils.class);
 
         Marshaller jaxbMarshaller = Mockito.mock(Marshaller.class);
         Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", jaxbMarshaller);
@@ -177,5 +178,16 @@ public class JAXBUtilCWTest {
         Mockito.doThrow(new JAXBException("")).when(jaxbMarshaller).marshal(Mockito.any(), Mockito.any(Writer.class));
 
         JAXBUtilCW.marshall(new DescribeAlarmsResponse(), "Test", "2012-02-10");
+        Whitebox.setInternalState(JAXBUtilCW.class, "jaxbMarshaller", getMarshaller());
+    }
+
+    public Marshaller getMarshaller() throws JAXBException {
+        JAXBContext jaxbContext = JAXBContext.newInstance("com.tlswe.awsmock.cloudwatch.cxf_generated");
+        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        jaxbMarshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
+
+        return jaxbMarshaller;
     }
 }

--- a/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
+++ b/src/test/java/com/tlswe/awsmock/cloudwatch/util/JAXBUtilCWTest.java
@@ -1,27 +1,28 @@
 package com.tlswe.awsmock.cloudwatch.util;
 
-import javax.xml.bind.JAXBException;
-
-import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
-
 import com.tlswe.awsmock.cloudwatch.control.MockCloudWatchQueryHandler;
 import com.tlswe.awsmock.cloudwatch.cxf_generated.DescribeAlarmsResponse;
 import com.tlswe.awsmock.cloudwatch.cxf_generated.GetMetricStatisticsResponse;
 import com.tlswe.awsmock.common.exception.AwsMockException;
 import com.tlswe.awsmock.common.util.Constants;
 import com.tlswe.awsmock.common.util.PropertiesUtils;
-import com.tlswe.awsmock.ec2.util.JAXBUtil;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import javax.xml.bind.JAXBException;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockCloudWatchQueryHandler.class, PropertiesUtils.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class JAXBUtilCWTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/common/listener/AppServletContextListenerTest.java
+++ b/src/test/java/com/tlswe/awsmock/common/listener/AppServletContextListenerTest.java
@@ -1,10 +1,9 @@
 package com.tlswe.awsmock.common.listener;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.servlet.ServletContextEvent;
-
+import com.tlswe.awsmock.common.util.PersistenceUtils;
+import com.tlswe.awsmock.common.util.PersistenceUtils.PersistenceStoreType;
+import com.tlswe.awsmock.ec2.control.*;
+import com.tlswe.awsmock.ec2.model.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,22 +14,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import com.tlswe.awsmock.common.util.PersistenceUtils;
-import com.tlswe.awsmock.common.util.PersistenceUtils.PersistenceStoreType;
-import com.tlswe.awsmock.ec2.control.MockEc2Controller;
-import com.tlswe.awsmock.ec2.control.MockInternetGatewayController;
-import com.tlswe.awsmock.ec2.control.MockRouteTableController;
-import com.tlswe.awsmock.ec2.control.MockSubnetController;
-import com.tlswe.awsmock.ec2.control.MockTagsController;
-import com.tlswe.awsmock.ec2.control.MockVolumeController;
-import com.tlswe.awsmock.ec2.control.MockVpcController;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
-import com.tlswe.awsmock.ec2.model.MockInternetGateway;
-import com.tlswe.awsmock.ec2.model.MockRouteTable;
-import com.tlswe.awsmock.ec2.model.MockSubnet;
-import com.tlswe.awsmock.ec2.model.MockTags;
-import com.tlswe.awsmock.ec2.model.MockVolume;
-import com.tlswe.awsmock.ec2.model.MockVpc;
+import javax.servlet.ServletContextEvent;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
@@ -227,19 +213,19 @@ public class AppServletContextListenerTest {
         Whitebox.setInternalState(AppServletContextListener.class, "persistenceEnabled", true);
         acl.contextDestroyed(sce);
 
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new AbstractMockEc2Instance[1]).getClass()), eq(PersistenceStoreType.EC2));
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new MockVpc[1]).getClass()), eq(PersistenceStoreType.VPC));
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new MockVolume[1]).getClass()), eq(PersistenceStoreType.VOLUME));
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new MockTags[1]).getClass()), eq(PersistenceStoreType.TAGS));
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new MockSubnet[1]).getClass()), eq(PersistenceStoreType.SUBNET));
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new MockRouteTable[1]).getClass()), eq(PersistenceStoreType.ROUTETABLE));
-        verifyStatic();
+        verifyStatic(PersistenceUtils.class);
         PersistenceUtils.saveAll(isA((new MockInternetGateway[1]).getClass()), eq(PersistenceStoreType.INTERNETGATEWAY));
         PowerMockito.verifyNoMoreInteractions(PersistenceUtils.class);
         

--- a/src/test/java/com/tlswe/awsmock/common/util/PersistenceUtilsTest.java
+++ b/src/test/java/com/tlswe/awsmock/common/util/PersistenceUtilsTest.java
@@ -1,13 +1,6 @@
 package com.tlswe.awsmock.common.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
+import com.tlswe.awsmock.common.util.PersistenceUtils.PersistenceStoreType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,11 +8,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
-import com.tlswe.awsmock.common.util.PersistenceUtils.PersistenceStoreType;
+import java.io.*;
 
 
 
@@ -27,6 +20,8 @@ import com.tlswe.awsmock.common.util.PersistenceUtils.PersistenceStoreType;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ File.class, PersistenceUtils.class, ObjectInputStream.class,
         FileInputStream.class, ObjectOutputStream.class, FileOutputStream.class, PersistenceStoreType.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class PersistenceUtilsTest {
 
     @Mock

--- a/src/test/java/com/tlswe/awsmock/common/util/TemplateUtilsTest.java
+++ b/src/test/java/com/tlswe/awsmock/common/util/TemplateUtilsTest.java
@@ -1,28 +1,29 @@
 package com.tlswe.awsmock.common.util;
 
+import com.tlswe.awsmock.common.exception.AwsMockException;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
-
-import com.tlswe.awsmock.common.exception.AwsMockException;
-
-import freemarker.template.Configuration;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ Configuration.class, Template.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class TemplateUtilsTest {
 
     private final String errFTemplateFile = "error.xml.ftl";

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandlerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockEC2QueryHandlerTest.java
@@ -1,23 +1,14 @@
 package com.tlswe.awsmock.ec2.control;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-
-import javax.servlet.http.HttpServletResponse;
-
+import com.tlswe.awsmock.common.util.Constants;
+import com.tlswe.awsmock.common.util.PropertiesUtils;
+import com.tlswe.awsmock.ec2.cxf_generated.*;
+import com.tlswe.awsmock.ec2.exception.BadEc2RequestException;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceState;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
+import com.tlswe.awsmock.ec2.util.JAXBUtil;
+import com.tlswe.example.CustomMockEc2Instance;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,56 +16,26 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import com.tlswe.awsmock.common.util.Constants;
-import com.tlswe.awsmock.common.util.PropertiesUtils;
-import com.tlswe.awsmock.ec2.cxf_generated.AvailabilityZoneItemType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateInternetGatewayResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateRouteTableResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateSecurityGroupResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateSubnetResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateTagsResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateVolumeResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.CreateVpcResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DeleteInternetGatewayResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DeleteRouteTableResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DeleteTagsResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DeleteVolumeResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DeleteVpcResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeAvailabilityZonesResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseInfoType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseItemType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeImagesResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeInstancesResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeInternetGatewaysResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeRouteTablesResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeSecurityGroupsResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeSubnetsResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeTagsResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeVolumesResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.DescribeVpcsResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.InternetGatewayType;
-import com.tlswe.awsmock.ec2.cxf_generated.IpPermissionType;
-import com.tlswe.awsmock.ec2.cxf_generated.ReservationInfoType;
-import com.tlswe.awsmock.ec2.cxf_generated.RunInstancesResponseType;
-import com.tlswe.awsmock.ec2.cxf_generated.RunningInstancesItemType;
-import com.tlswe.awsmock.ec2.cxf_generated.RunningInstancesSetType;
-import com.tlswe.awsmock.ec2.cxf_generated.SecurityGroupItemType;
-import com.tlswe.awsmock.ec2.cxf_generated.VpcType;
-import com.tlswe.awsmock.ec2.exception.BadEc2RequestException;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceState;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
-import com.tlswe.awsmock.ec2.util.JAXBUtil;
-import com.tlswe.example.CustomMockEc2Instance;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockEC2QueryHandler.class, MockEc2Controller.class, MockInternetGatewayController.class, MockRouteTableController.class,
     MockSubnetController.class, MockVolumeController.class, MockVpcController.class, MockTagsController.class, MockSecurityGroupController.class,
     JAXBUtil.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockEC2QueryHandlerTest {
 
     private static Properties properties = new Properties();

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockEc2ControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockEc2ControllerTest.java
@@ -1,31 +1,27 @@
 package com.tlswe.awsmock.ec2.control;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.common.exception.AwsMockException;
+import com.tlswe.awsmock.ec2.exception.BadEc2RequestException;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
+import com.tlswe.awsmock.ec2.model.DefaultMockEc2Instance;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.common.exception.AwsMockException;
-import com.tlswe.awsmock.ec2.exception.BadEc2RequestException;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
-import com.tlswe.awsmock.ec2.model.DefaultMockEc2Instance;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockEc2Controller.class, DefaultMockEc2Instance.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockEc2ControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockInternetGatewayControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockInternetGatewayControllerTest.java
@@ -1,24 +1,25 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.ec2.model.MockInternetGateway;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.ec2.model.MockInternetGateway;
-import com.tlswe.awsmock.ec2.model.MockVpc;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockInternetGatewayController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockInternetGatewayControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockRouteTableControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockRouteTableControllerTest.java
@@ -1,25 +1,25 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.ec2.model.MockRouteTable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.ec2.model.MockInternetGateway;
-import com.tlswe.awsmock.ec2.model.MockRouteTable;
-import com.tlswe.awsmock.ec2.model.MockVpc;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockRouteTableController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockRouteTableControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockSecurityGroupControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockSecurityGroupControllerTest.java
@@ -1,24 +1,25 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.ec2.model.MockSecurityGroup;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.ec2.model.MockRouteTable;
-import com.tlswe.awsmock.ec2.model.MockSecurityGroup;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockSecurityGroupController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockSecurityGroupControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockSubnetControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockSubnetControllerTest.java
@@ -1,25 +1,25 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.ec2.model.MockSubnet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.ec2.model.MockSecurityGroup;
-import com.tlswe.awsmock.ec2.model.MockSubnet;
-import com.tlswe.awsmock.ec2.model.MockVpc;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockSubnetController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockSubnetControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockTagsControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockTagsControllerTest.java
@@ -1,27 +1,22 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.ec2.model.MockTags;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.amazonaws.services.ec2.model.Tag;
-import com.tlswe.awsmock.ec2.model.MockSubnet;
-import com.tlswe.awsmock.ec2.model.MockTags;
+import java.util.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockTagsController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockTagsControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockVolumeControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockVolumeControllerTest.java
@@ -1,22 +1,25 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.tlswe.awsmock.ec2.model.MockVolume;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.ec2.model.MockVolume;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockVolumeController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockVolumeControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/control/MockVpcControllerTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/control/MockVpcControllerTest.java
@@ -1,24 +1,25 @@
 package com.tlswe.awsmock.ec2.control;
 
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.tlswe.awsmock.ec2.model.MockVpc;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.tlswe.awsmock.ec2.model.MockVolume;
-import com.tlswe.awsmock.ec2.model.MockVpc;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockVpcController.class})
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class MockVpcControllerTest {
 
     @Test

--- a/src/test/java/com/tlswe/awsmock/ec2/model/DefaultMockEc2InstanceTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/model/DefaultMockEc2InstanceTest.java
@@ -1,23 +1,25 @@
 package com.tlswe.awsmock.ec2.model;
 
+import com.tlswe.awsmock.common.util.Constants;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceState;
+import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
-
-import com.tlswe.awsmock.common.util.Constants;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceState;
-import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ AbstractMockEc2Instance.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class DefaultMockEc2InstanceTest {
 
     private static final String MAX_BOOT_TIME_MILLS = "MAX_BOOT_TIME_MILLS";

--- a/src/test/java/com/tlswe/awsmock/ec2/model/DefaultMockEc2InstanceTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/model/DefaultMockEc2InstanceTest.java
@@ -11,8 +11,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -126,7 +124,8 @@ public class DefaultMockEc2InstanceTest {
     @Test
     public void Test_timerInstanceStartedMaxBoot0() throws Exception {
 
-        setFinalStatic(AbstractMockEc2Instance.class.getDeclaredField(MAX_BOOT_TIME_MILLS), 0);
+        Whitebox.setInternalState(AbstractMockEc2Instance.class, "MAX_BOOT_TIME_MILLS", 0);
+
         AbstractMockEc2Instance defaultMockEc2Instance = new DefaultMockEc2Instance();
 
         defaultMockEc2Instance.setInstanceType(InstanceType.C1_MEDIUM);
@@ -144,8 +143,7 @@ public class DefaultMockEc2InstanceTest {
                 Constants.PROP_NAME_INSTANCE_MAX_BOOT_TIME,
                 Constants.PROP_NAME_INSTANCE_MAX_BOOT_TIME_SECONDS);
 
-        setFinalStatic(AbstractMockEc2Instance.class.getDeclaredField(MAX_BOOT_TIME_MILLS),
-                resetValue);
+        Whitebox.setInternalState(AbstractMockEc2Instance.class, "MAX_BOOT_TIME_MILLS", resetValue);
 
         Assert.assertFalse(defaultMockEc2Instance.isBooting());
         Assert.assertNotNull(defaultMockEc2Instance.getPubDns());
@@ -170,7 +168,8 @@ public class DefaultMockEc2InstanceTest {
     @Test
     public void Test_timerInstanceStoppedMaxShutdown0() throws Exception {
 
-        setFinalStatic(AbstractMockEc2Instance.class.getDeclaredField(MAX_SHUTDOWN_TIME_MILLS), 0);
+        Whitebox.setInternalState(AbstractMockEc2Instance.class, "MAX_SHUTDOWN_TIME_MILLS", 0);
+
         AbstractMockEc2Instance defaultMockEc2Instance = new DefaultMockEc2Instance();
 
         defaultMockEc2Instance.setInstanceType(InstanceType.C1_MEDIUM);
@@ -189,8 +188,7 @@ public class DefaultMockEc2InstanceTest {
                 Constants.PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME,
                 Constants.PROP_NAME_INSTANCE_MAX_SHUTDOWN_TIME_SECONDS);
 
-        setFinalStatic(AbstractMockEc2Instance.class.getDeclaredField(MAX_SHUTDOWN_TIME_MILLS),
-                resetValue);
+        Whitebox.setInternalState(AbstractMockEc2Instance.class, "MAX_SHUTDOWN_TIME_MILLS", resetValue);
 
         Assert.assertFalse(defaultMockEc2Instance.isStopping());
         Assert.assertFalse(defaultMockEc2Instance.isRunning());
@@ -210,14 +208,6 @@ public class DefaultMockEc2InstanceTest {
         defaultMockEc2Instance.setSecurityGroups(securityGroups);
 
         Assert.assertTrue(defaultMockEc2Instance.getSecurityGroups() == securityGroups);
-    }
-
-    static void setFinalStatic(Field field, Object newValue) throws Exception {
-        field.setAccessible(true);
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, newValue);
     }
 
 }

--- a/src/test/java/com/tlswe/awsmock/ec2/util/JAXBUtilTest.java
+++ b/src/test/java/com/tlswe/awsmock/ec2/util/JAXBUtilTest.java
@@ -1,23 +1,25 @@
 package com.tlswe.awsmock.ec2.util;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
-
 import com.tlswe.awsmock.common.exception.AwsMockException;
 import com.tlswe.awsmock.common.util.Constants;
 import com.tlswe.awsmock.common.util.PropertiesUtils;
 import com.tlswe.awsmock.ec2.control.MockEC2QueryHandler;
 import com.tlswe.awsmock.ec2.cxf_generated.RunInstancesResponseType;
 import com.tlswe.awsmock.ec2.model.AbstractMockEc2Instance.InstanceType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MockEC2QueryHandler.class, PropertiesUtils.class })
+@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
+        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
 public class JAXBUtilTest {
 
     @Test


### PR DESCRIPTION
- Update build.gradle to provide jaxws-api in runtime as it is no longer provided by default in newer JDKs
- Update PowerMock to latest version 2.0.9 to fix issue of IllegalAccessError. Fixes compatiblity issues with newer JDK versions (9 and onwards) by using PowerMockIgnore.
- Organize imports in affected classes
- Remove two tests to avoid internal conflicts due to static access